### PR TITLE
Fixed diacritical marks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,7 @@ RUN apt-get clean \
   && rm -rf /tmp/*
 
 # Set Locale env
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-
-# Set Locale
-RUN locale-gen en_US en_US.UTF-8
-RUN dpkg-reconfigure locales 
+ENV LANG C.UTF-8
 
 # default http https port
 EXPOSE 4040 4050


### PR DESCRIPTION
Regardless of ENV en_US.UTF-8 and locale-gen en_US.UTF-8, diacritical marks (öäü and more) are broken.

Build with "ENV LANG C.UTF-8" fixes the diacritical marks.

Official [docker openjdk-8](https://github.com/docker-library/openjdk/blob/master/8-jre/Dockerfile) image is also build with "ENV LANG C.UTF-8".
